### PR TITLE
convert the changes in post receive into a json array

### DIFF
--- a/lib/gitlab_access.rb
+++ b/lib/gitlab_access.rb
@@ -12,7 +12,7 @@ class GitlabAccess
     @config = GitlabConfig.new
     @repo_path, @actor = repo_path.strip, actor
     @repo_name = extract_repo_name(@repo_path.dup, config.repos_path.to_s)
-    @changes = changes.lines
+    @changes = changes.lines.to_a
   end
 
   def exec

--- a/lib/gitlab_post_receive.rb
+++ b/lib/gitlab_post_receive.rb
@@ -9,7 +9,7 @@ class GitlabPostReceive
   def initialize(repo_path, actor, changes)
     @config = GitlabConfig.new
     @repo_path, @actor = repo_path.strip, actor
-    @changes = changes.lines
+    @changes = changes.lines.to_a
   end
 
   def exec
@@ -46,7 +46,7 @@ class GitlabPostReceive
       repo = @repo_path.gsub("#{config.repos_path}/", "")
       msg = JSON.dump({'type' => 'post_receive', 'repo' => repo, 'repo_path' => @repo_path, 'actor' => @actor, 'changes' => @changes})
       queue.publish(msg, :persistent => true, :content_type => "application/json")
-      $logger.info { "Published post_receive message to rabbit repo=#{repo} actor=#{@actor}" }
+      $logger.info { "Published post_receive message to rabbit repo=#{repo} actor=#{@actor} changes=#{@changes}" }
       # All done, clean up
       conn.close
     rescue Exception => e


### PR DESCRIPTION
This change will make sure the `changes` passed to the gitlab-shell post receive hook will become a json array when publish to the message bus. Otherwise it will be something like '#<Enumerator:0x000000016d2530>'