### PR TITLE
Send sshd logs to stderr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ RUN ["bash", "-c", "mkdir ../gitlab-config && \
                      chown -R git:git /home/git"]
 
 EXPOSE 22
-CMD [ "/usr/sbin/sshd", "-D" ]
+CMD ["/usr/sbin/sshd", "-D", "-e"]


### PR DESCRIPTION
Sending logs to stderr instead of system logs allows us to conveniently
see the log stream from the docker logs / OpenShift web console.