### PR TITLE
RHMAP-7636 - Init script permission tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN mkdir /home/git/gitlab-config && \
           -e "s|^[#]*GSSAPIAuthentication yes|GSSAPIAuthentication no|" \
           -e "s|^[#]*ChallengeResponseAuthentication no|ChallengeResponseAuthentication no|" \
           -e "s|^[#]*PasswordAuthentication yes|PasswordAuthentication no|" \
+          -e "s|^[#]*StrictModes yes|StrictModes no|" \
           /etc/ssh/sshd_config && \
     echo -e "UseDNS no \nAuthenticationMethods publickey" >> /etc/ssh/sshd_config && \
     chmod -Rf +x /home/git/gitlab-shell/bin

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 
-## Container startup script
+## Startup script for gitlabshell.
+## This script initializes gitlabshell installation by setting up 
+## proper folder permissions and adding initial authorized_keys
+
+set -o errexit
+set -o nounset
+set -o pipefail
 
 ### Setup sshd configuration
 LOG_LEVEL=${LOG_LEVEL:-INFO}
@@ -8,21 +14,21 @@ LOG_LEVEL=${LOG_LEVEL:-INFO}
 echo "Setting sshd LogLevel to $LOG_LEVEL"
 sed -i "s/#LogLevel INFO/LogLevel ${LOG_LEVEL:-INFO}/" /etc/ssh/sshd_config
 
+### Mounted volume for git repositories
+GIT_REPO_ROOT=${GIT_REPO_ROOT:-/home/git/data}
+
 ### Setup keys
 SSH_SECRETS_DIR=${SSH_SECRETS_DIR:-/etc/feedhenry/gitlab-shell}
 SSH_FOLDER=/home/git/.ssh
 AUTHORIZED_KEYS_FILE=$SSH_FOLDER/authorized_keys
-
-## Mounted volume for git repositories
-GIT_REPO_ROOT=${GIT_REPO_ROOT:-/home/git/data}
+AUTHORIZED_KEYS_BACKUP_FOLDER=$GIT_REPO_ROOT/auth/.ssh
 
 echo "Initializing authorized_keys file"
 
-##### Store authorized_keys on persisted volume for backup
-mkdir -p $GIT_REPO_ROOT/.ssh/ /home/git/.ssh/
-touch -a $GIT_REPO_ROOT/.ssh/authorized_keys 
-
-ln -sf $GIT_REPO_ROOT/.ssh/authorized_keys $AUTHORIZED_KEYS_FILE  
+#### Store authorized_keys on persisted volume for backup
+mkdir -p $AUTHORIZED_KEYS_BACKUP_FOLDER $SSH_FOLDER
+touch -a $AUTHORIZED_KEYS_BACKUP_FOLDER/authorized_keys
+ln -sf $AUTHORIZED_KEYS_BACKUP_FOLDER/authorized_keys $AUTHORIZED_KEYS_FILE  
 
 SSH_CMD_PREFIX='command="export GL_ID=key-gitlabshelladmin;if [ -n \"$SSH_ORIGINAL_COMMAND\" ]; then eval \"$SSH_ORIGINAL_COMMAND\";else exec \"$SHELL\"; fi" '
 
@@ -52,22 +58,28 @@ else
   fi
 fi
 
-# Enable scl ruby package
+### Enable scl ruby package
 echo "source /opt/rh/rh-ruby23/enable" > /home/git/.bashrc
 
-## Run gitlab setup
+### Run gitlab setup
 ./bin/install
 
-## Map PV repositories
+### Map PV repositories
 ln -sf $GIT_REPO_ROOT/repositories /home/git/repositories
 
-### Setup permissions
+### Setup git home permissions
 chown -R git:git /home/git
 chmod -R o-rwx /home/git
 chmod 700 $GIT_REPO_ROOT
 
-## Enable non root ssh by removing nologin
+### Set backup volume permissions
+chmod 777 $GIT_REPO_ROOT
+chmod 777 $GIT_REPO_ROOT/repositories 
+chmod -R 700 $AUTHORIZED_KEYS_BACKUP_FOLDER/..
+chmod 600 $AUTHORIZED_KEYS_FILE
+
+### Enable non root ssh by removing nologin
 rm -f /run/nologin
 
-## Run sshd deamon
+### Run sshd deamon
 /usr/sbin/sshd -D -e


### PR DESCRIPTION
## Problem

Sharing volume between different containers is not possbile when permissions are set to specific system user on container. If folder is restricted to specific user it would not be accessible in other containers without that PID.

Solutions may include
- Set permission to common PID (not possible because of gitlab-shell limitations)
- Mount .ssh separatelly 
- Set more open permissions to folders and turn off sshd restrictions for permissions

## Changes made

- Allow to share persistent volume data between multiple containers in pod.
- Change script to fail on first error.

ping @maleck13 @grdryn 