### PR TITLE
Force git user to have uid:gid of 48 (apache)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ RUN ["bash", "-c", "yum install -y --setopt=tsflags=nodocs openssh-server libicu
      sshd-keygen && \
      mkdir /var/run/sshd && \
      gem install --no-ri --no-rdoc bunny && \
-     groupadd -r git && \
-     useradd -r -s /bin/bash -g git git && \
+     /usr/sbin/groupadd -g 48 git && \
+     useradd -r -s /bin/bash -u 48 -g 48 git && \
      mkdir --parent /home/git"]
 
 # gitlab-shell setup
@@ -22,7 +22,7 @@ RUN mkdir /home/git/gitlab-config && \
     cp config.yml.example ../gitlab-config/config.yml && \
     ln -s /home/git/gitlab-config/config.yml && \
     # PAM workarounds for docker and public key auth
-    sed -i \ 
+    sed -i \
           # Disable processing of user uid. See: https://gitlab.com/gitlab-org/gitlab-ce/issues/3027
           -e "s|session\s*required\s*pam_loginuid.so|session optional pam_loginuid.so|g" \
           # Allow non root users to login: http://man7.org/linux/man-pages/man8/pam_nologin.8.html


### PR DESCRIPTION
Motivation:
In OpenShift3, we have two different containers in the gitlab-shell Pod
that need to be able to read/write to the repositories: `gitlab-shell`
and `gitlab-httpd-proxy`. The latter gets started as root currently, and
spawns child procs as the `apache` user. It's these child procs that
need to be able to read/write from that container.  In the repos there
are some things that are only writable by the owner, such as the
`objects` directory, where data lives, so both containers will need to
be able to write to that.

Modification:
Since we create the `git` user in the `gitlab-shell` container image
ourselves, we can give it whatever uid we want, and also set the gid on
the corresponding group. The `apache` user and group provided by the
`httpd` RPM get both uid and gid set to 48, so this change makes the
`git` user match that.

It's possible (but probably rare) that the `httpd` RPM could set a
different uid:gid in future, which could break this. An alternative here
could be to install the `httpd` package here to get the `apache` user as
it would be in the other container, then use that user here instead of
the `git` user (it's a config option, unless we've gone and done
horrible things in our customizations like hardcoding references to that
user outside the config).

Result:
Both containers should now be able to read and write to the repositories
as expected, and as a result, users should be able to push their awesome
changes back to the repository.