### PR TITLE
switch gitlab to run as non root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,53 @@
 FROM registry.access.redhat.com/rhscl/ruby-23-rhel7
-
-# sshd
 USER root
-RUN ["bash", "-c", "yum install -y --setopt=tsflags=nodocs openssh-server libicu-devel && \
+# sshd
+RUN ["bash", "-c", "yum install -y --setopt=tsflags=nodocs openssh-server ed libicu-devel && \
      yum clean all && \
      sshd-keygen && \
-     mkdir /var/run/sshd && \
-     /usr/sbin/groupadd -g 48 git && \
-     useradd -r -m -s /bin/bash -u 48 -g 48 git"]
-
+     mkdir /var/run/sshd"]
+# add a user that id a member of the root group. we will replace later with the user assigned to the pod. Change perms to allow the root group to modify and use files as needed. These changes allow the pod assigned user to be part of the root group and have a real uid assigned
+RUN adduser --system -s /bin/bash -u 1234321 -g 0 git && \ 
+   chown root:root /etc/ssh/* /home && \
+   chmod 775 /etc/ssh /home && \  
+   chmod 660 /etc/ssh/sshd_config && \
+   chmod 664 /etc/passwd /etc/group && \
+   chmod 775 /var/run && \
+   mkdir -p /home/git/data/gls && \
+   chmod -R 775 /home/git
+  
+EXPOSE 2022
 # gitlab-shell setup
+USER git
 COPY . /home/git/gitlab-shell
 WORKDIR /home/git/gitlab-shell
-
 RUN ["bash", "-c", "bundle"]
 
 RUN mkdir /home/git/gitlab-config && \
     ## Setup default config placeholder
-    cp config.yml.example ../gitlab-config/config.yml && \
-    ln -s /home/git/gitlab-config/config.yml && \
+    cp config.yml.example ../gitlab-config/config.yml
     # PAM workarounds for docker and public key auth
-    sed -i \
+USER root    
+RUN sed -i \
           # Disable processing of user uid. See: https://gitlab.com/gitlab-org/gitlab-ce/issues/3027
           -e "s|session\s*required\s*pam_loginuid.so|session optional pam_loginuid.so|g" \
           # Allow non root users to login: http://man7.org/linux/man-pages/man8/pam_nologin.8.html
           -e "s|account\s*required\s*pam_nologin.so|#account optional pam_nologin.so|g" \
-          /etc/pam.d/sshd && \
+          /etc/pam.d/sshd
     # Security recommendations for sshd
-    sed -i \
+RUN sed -i \
           -e "s|^[#]*GSSAPIAuthentication yes|GSSAPIAuthentication no|" \
+          -e 's/#UsePrivilegeSeparation.*$/UsePrivilegeSeparation no/' \
+          -e 's/#Port.*$/Port 2022/' \
           -e "s|^[#]*ChallengeResponseAuthentication no|ChallengeResponseAuthentication no|" \
           -e "s|^[#]*PasswordAuthentication yes|PasswordAuthentication no|" \
           -e "s|^[#]*StrictModes yes|StrictModes no|" \
           /etc/ssh/sshd_config && \
-    echo -e "UseDNS no \nAuthenticationMethods publickey" >> /etc/ssh/sshd_config && \
-    chmod -Rf +x /home/git/gitlab-shell/bin
+    echo -e "UseDNS no \nAuthenticationMethods publickey" >> /etc/ssh/sshd_config
 
-EXPOSE 22
-CMD ["bin/start.sh"]
+RUN rm -f /run/nologin && \
+    ln -s /home/git/gitlab-config/config.yml && \
+    chmod -R 775 /home/git
+
+USER git
+
+CMD echo -e ",s/1234321/`id -u`/g\\012 w" | ed -s /etc/passwd && ssh-keygen -A && bin/start.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN adduser --system -s /bin/bash -u 1234321 -g 0 git && \
    chmod 664 /etc/passwd /etc/group && \
    chmod 775 /var/run && \
    mkdir -p /home/git/data/gls && \
-   chmod -R 775 /home/git
+   chmod -R 775 /home/git && \
+   chmod -R 775 /opt/app-root
   
 EXPOSE 2022
 # gitlab-shell setup

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,16 +18,15 @@ RUN adduser --system -s /bin/bash -u 1234321 -g 0 git && \
   
 EXPOSE 2022
 # gitlab-shell setup
-USER git
+USER root
 COPY . /home/git/gitlab-shell
 WORKDIR /home/git/gitlab-shell
 RUN ["bash", "-c", "bundle"]
-
 RUN mkdir /home/git/gitlab-config && \
     ## Setup default config placeholder
     cp config.yml.example ../gitlab-config/config.yml
     # PAM workarounds for docker and public key auth
-USER root    
+
 RUN sed -i \
           # Disable processing of user uid. See: https://gitlab.com/gitlab-org/gitlab-ce/issues/3027
           -e "s|session\s*required\s*pam_loginuid.so|session optional pam_loginuid.so|g" \

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -6,6 +6,10 @@
 LOG_LEVEL=${LOG_LEVEL:-INFO}
 
 echo "Setting sshd LogLevel to $LOG_LEVEL"
+
+chmod -R o-rwx $GIT_REPO_ROOT
+chmod 700 $GIT_REPO_ROOT
+
 sed -i "s/#LogLevel INFO/LogLevel ${LOG_LEVEL:-INFO}/" /etc/ssh/sshd_config
 
 ### Setup keys
@@ -73,13 +77,10 @@ echo "Starting tail of gitlab-shell log file to output all logs to stdout"
 (tail -f /home/git/gitlab-shell/gitlab-shell.log ; echo "gitlab-shell logging stopped unexpectedly") &
 
 ### Setup permissions
-chown -R git:git /home/git
-chown root:root $GIT_REPO_MOUNT
 chmod -R o-rwx $GIT_REPO_ROOT
 chmod 700 $GIT_REPO_ROOT
 
 ## Enable non root ssh by removing nologin
-rm -f /run/nologin
 
 ## Run sshd deamon
 /usr/sbin/sshd -D -e

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 
+set -e
+
 ## Container startup script
 
 ### Setup sshd configuration
 LOG_LEVEL=${LOG_LEVEL:-INFO}
 
 echo "Setting sshd LogLevel to $LOG_LEVEL"
-
-chmod -R o-rwx $GIT_REPO_ROOT
-chmod 700 $GIT_REPO_ROOT
 
 sed -i "s/#LogLevel INFO/LogLevel ${LOG_LEVEL:-INFO}/" /etc/ssh/sshd_config
 


### PR DESCRIPTION
@wtrocki @grdryn @david-martin  
Similar changes to the httpd container. To allow ssh and gitlab-shell to run as a non root user.

Further testing this I found the git post receive hook does not seem to be working so the project create hangs.
Any thoughts on how to debug?